### PR TITLE
feat: add auto-save option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Customize inline with lazy.nvim if you need different bindings:
   config = function()
     require("headhunter").setup({
       enabled = true,         -- set to false to opt out entirely
+      auto_save = false,      -- default; set true to auto-write after resolving
       keys = {
         next = "]c",         -- remap `]g` → `]c`
         prev = "[c",          -- remap `[g` → `[c`
@@ -47,6 +48,9 @@ Customize inline with lazy.nvim if you need different bindings:
   end,
 }
 ```
+
+Enable `auto_save = true` to have headhunter.nvim silently write the buffer
+after applying a resolution. The default is `false`.
 
 ---
 

--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -28,8 +28,11 @@ end
 
 local defaultConfig = {
     enabled = true,
+    auto_save = false,
     keys = vim.deepcopy(default_keys),
 }
+
+local config = vim.deepcopy(defaultConfig)
 
 -- Parses git grep output (testable, can be called by tests)
 function M._parse_conflicts(output)
@@ -207,6 +210,12 @@ local function apply_resolution(mode)
         false,
         replacement
     )
+
+    if config.auto_save then
+        vim.api.nvim_buf_call(bufnr, function()
+            vim.cmd("silent noautocmd write")
+        end)
+    end
 end
 
 function M.take_head()
@@ -243,10 +252,11 @@ function M._register_keymaps(config)
     map(keys.quickfix, M.populate_quickfix, "List Git conflicts")
 end
 
-local config = vim.deepcopy(defaultConfig)
-
 function M.setup(user_config)
     local opts = vim.deepcopy(user_config or {})
+    if opts.auto_save ~= nil and type(opts.auto_save) ~= "boolean" then
+        error("headhunter.nvim: `auto_save` must be a boolean or nil")
+    end
     if opts.keys ~= nil and opts.keys ~= false then
         if type(opts.keys) ~= "table" then
             error("headhunter.nvim: `keys` must be a table, false, or nil")
@@ -282,6 +292,10 @@ function M.setup(user_config)
     end
 
     if config.enabled == false then
+        return
+    end
+
+    if config.keys == false then
         return
     end
 

--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -213,7 +213,7 @@ local function apply_resolution(mode)
 
     if config.auto_save then
         vim.api.nvim_buf_call(bufnr, function()
-            vim.cmd("silent noautocmd write")
+            vim.cmd("silent write")
         end)
     end
 end

--- a/plans/auto-save-option.md
+++ b/plans/auto-save-option.md
@@ -1,5 +1,0 @@
-# Auto-Save Option Plan
-
-- Introduce `auto_save = false` in `defaultConfig` and validate user input so only booleans are accepted.
-- Extend `apply_resolution` to check `config.auto_save`; when true, issue a silent, local buffer write via `vim.api.nvim_buf_call(bufnr, function() vim.cmd("silent noautocmd write") end)`.
-- Document the new configuration flag in `README.md`, noting the default and giving a sample `require("headhunter").setup` snippet.

--- a/plans/conflict-refresh-and-quickfix.md
+++ b/plans/conflict-refresh-and-quickfix.md
@@ -1,7 +1,0 @@
-# Conflict Refresh & Quickfix Sync Plan
-
-- Add a helper that recomputes conflicts via `M._get_conflicts()`, refreshes the module-level `conflicts` cache, and clamps `current_index` so navigation skips resolved hunks.
-- Call the helper at the end of `apply_resolution` so the next navigation command lands on the next unresolved conflict.
-- Track whether `M.populate_quickfix` seeded the quickfix list (for example with a `quickfix_active` flag) and, when conflicts are refreshed, rebuild the quickfix entries using `build_quickfix_entries` only when the flag is set; clear or close the list when no conflicts remain.
-- Emit a short status message when the quickfix list or navigation pool becomes empty to match existing UX.
-- Update `README.md` to mention that quickfix entries now stay in sync with the resolved conflicts.


### PR DESCRIPTION
This pull request adds a new `auto_save` configuration option to `headhunter.nvim`, allowing users to automatically save the buffer after resolving a conflict. The option is disabled by default and can be enabled for a smoother workflow. The changes also update documentation and improve configuration validation.

**New Feature: Auto-Save Option**

* Added `auto_save` setting to the configuration in `lua/headhunter/init.lua` and exposed it to users via the setup function. This enables automatic buffer saving after conflict resolution when set to `true`. [[1]](diffhunk://#diff-21baa621b9d61052ffe4e14b77a23af2246c86965a797c5d96e0bbb12b70b6a9R31-R36) [[2]](diffhunk://#diff-21baa621b9d61052ffe4e14b77a23af2246c86965a797c5d96e0bbb12b70b6a9R213-R218)
* Updated documentation in `README.md` to describe the new `auto_save` option and its default behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R54)

**Configuration Improvements**

* Added validation to ensure `auto_save` is a boolean or nil, raising an error otherwise.
* Adjusted keymap registration logic to account for the new configuration flow.