### PR TITLE
Refresh conflicts after resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Neovim plugin that helps you quickly **navigate and resolve merge conflicts** 
   - **Take HEAD** (`<<<<<<< HEAD`) – keeps your local changes.
   - **Take origin** (`>>>>>>> ...`) – keeps the incoming changes.
   - **Take both** – keeps both changes, concatenated in order.
+- Keep the quickfix list in sync while you resolve conflicts, and close it automatically when you're done.
 - Minimal and fast — pure Lua implementation with no external dependencies.
 - Fully customizable keybindings to fit your workflow.
 

--- a/lua/headhunter/init.lua
+++ b/lua/headhunter/init.lua
@@ -260,6 +260,12 @@ local function apply_resolution(mode)
         replacement
     )
 
+    if config.auto_save then
+        vim.api.nvim_buf_call(bufnr, function()
+            vim.cmd("silent write")
+        end)
+    end
+
     refresh_conflicts({ after_resolution = true })
 end
 

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,2 +1,5 @@
-nvim --headless -u scripts/minimal_init.lua -c "PlenaryBustedDirectory lua/tests/ { minimal_init = 'scripts/minimal_init.lua', file_pattern = '*_spec.lua' }" -c "qa"
+local cwd = vim.fn.getcwd()
 
+vim.opt.runtimepath:append(cwd)
+
+pcall(vim.cmd, "packadd plenary.nvim")


### PR DESCRIPTION
This pull request introduces improvements to the Neovim plugin's merge conflict resolution workflow, focusing on better quickfix list management and enhanced user experience. The main changes ensure that the quickfix list stays up-to-date as conflicts are resolved, closes automatically when all conflicts are handled, and adds robust test coverage for these behaviors.

**Quickfix list management and user experience:**

* Added logic to automatically refresh the quickfix list as conflicts are resolved, clear it when no conflicts remain, and close the quickfix window for a smoother workflow (`lua/headhunter/init.lua`). [[1]](diffhunk://#diff-21baa621b9d61052ffe4e14b77a23af2246c86965a797c5d96e0bbb12b70b6a9R115-R165) [[2]](diffhunk://#diff-21baa621b9d61052ffe4e14b77a23af2246c86965a797c5d96e0bbb12b70b6a9L135-R192) [[3]](diffhunk://#diff-21baa621b9d61052ffe4e14b77a23af2246c86965a797c5d96e0bbb12b70b6a9R259-R260)
* Updated the README to mention that the quickfix list stays in sync during conflict resolution and closes automatically when finished (`README.md`).

**Testing and reliability improvements:**

* Expanded test coverage to verify that the quickfix list updates correctly, including clearing after conflict resolution and maintaining accurate entries when conflicts change (`lua/tests/quickfix_spec.lua`).
* Added cleanup logic in tests to close the quickfix window before and after each test, preventing interference between tests (`lua/tests/quickfix_spec.lua`).

**Configuration and setup:**

* Improved plugin setup to respect user configuration for keybindings, allowing disabling of key mappings if desired (`lua/headhunter/init.lua`).